### PR TITLE
upgrade scala to 2.11.8 and scalaz to 7.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "net.bmjames"
 
 name := "scala-optparse-applicative"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
-crossScalaVersions := List("2.10.6", "2.11.7")
+crossScalaVersions := List("2.10.6", "2.11.8")
 
 scalacOptions ++= List(
   "-feature",

--- a/src/main/scala/net/bmjames/opts/common/Common.scala
+++ b/src/main/scala/net/bmjames/opts/common/Common.scala
@@ -36,7 +36,7 @@ private[opts] trait Common {
       case _ => None
     }
 
-  private def argsMState[F[_]: Monad] = MonadState[({type λ[β]=StateT[F,Args,β]})#λ, Args]
+  private def argsMState[F[_]: Monad] = MonadState[({type λ[α]=StateT[F,Args,α]})#λ, Args]
 
   def optMatches[F[_], A](disambiguate: Boolean, opt: OptReader[A], word: OptWord)(implicit F: MonadP[F]): Option[StateT[F, Args, A]] = {
     def hasName(n: OptName, ns: List[OptName]): Boolean =

--- a/src/main/scala/net/bmjames/opts/internal/NondetT.scala
+++ b/src/main/scala/net/bmjames/opts/internal/NondetT.scala
@@ -50,7 +50,7 @@ object NondetT {
       }
 
   protected def ltmp[F[_]: Monad] = listTMonadPlus[BoolState[F]#λ]
-  protected def mState[F[_]: Monad] = MonadState[({type λ[β]=StateT[F,Boolean,β]})#λ, Boolean]
+  protected def mState[F[_]: Monad] = MonadState[({type λ[α]=StateT[F,Boolean,α]})#λ, Boolean]
 
   implicit def nondetTMonadPlus[F[_] : Monad]: MonadPlus[({type λ[α]=NondetT[F,α]})#λ] =
     new MonadPlus[({type λ[α] = NondetT[F, α]})#λ] {

--- a/src/test/scala/net/bmjames/opts/test/example/ValidationExample.scala
+++ b/src/test/scala/net/bmjames/opts/test/example/ValidationExample.scala
@@ -38,7 +38,7 @@ object ValidationExample {
       case Success(UserData(u, e)) =>
         println(s"Congratulations, $u <$e>, you are officially super-valid.")
       case Failure(errors) =>
-        errors.list.toList.foreach(System.err.println)
+        errors.foreach(System.err.println)
         System.exit(1)
     }
   }


### PR DESCRIPTION
Hi James,

We have recently upgraded to scala 2.11.8 and scalaz 7.2.2 where I work, which means we would like a version of scala-optparse-applicative compatible with scalaz 7.2. I am not sure what other users are using, but as long as they are happy it would be great if you could merge this and release a new version targeting scalaz 7.2.

Thanks,
Sam