### PR TITLE
Add support for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "scala-optparse-applicative"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := List("2.10.6", "2.11.8")
+crossScalaVersions := List("2.10.6", "2.11.8", "2.12.0")
 
 scalacOptions ++= List(
   "-feature",
@@ -17,6 +17,6 @@ scalacOptions ++= List(
   "-language:higherKinds")
 
 libraryDependencies ++= List(
-  "org.scalaz" %% "scalaz-core" % "7.2.4",
-  "com.googlecode.kiama" %% "kiama" % "1.7.0",
-  "org.scalacheck" %% "scalacheck" % "1.12.5" % "test")
+  "org.scalaz" %% "scalaz-core" % "7.2.7",
+  "com.googlecode.kiama" %% "kiama" % "1.8.0",
+  "org.scalacheck" %% "scalacheck" % "1.12.6" % "test")

--- a/src/main/scala/net/bmjames/opts/internal/NondetT.scala
+++ b/src/main/scala/net/bmjames/opts/internal/NondetT.scala
@@ -11,8 +11,7 @@ final case class NondetT[F[_], A](run: ListT[BoolState[F]#λ, A]) {
 
   def !(that: NondetT[F, A])(implicit F: Monad[F]): NondetT[F, A] = {
     val run2 = for {
-      s <- mState[F].get.liftM[ListT]
-      if !s
+      s  <- mState[F].get.liftM[ListT].filter(!_)
       a2 <- that.run
     } yield a2
     NondetT(ltmp[F].plus(run, run2))


### PR DESCRIPTION
This updates some libraries for 2.12 support. One code change re: `ListT` which doesn't have `withFilter`. I didn't bump the version number.