### PR TITLE
Change pretty printing to linear bounded

### DIFF
--- a/src/main/scala/net/bmjames/opts/helpdoc/Chunk.scala
+++ b/src/main/scala/net/bmjames/opts/helpdoc/Chunk.scala
@@ -78,7 +78,7 @@ object Chunk {
 
   /** Concatenate Chunks vertically separated by empty lines. */
   def vsepChunks(chunks: List[Chunk[Doc]]): Chunk[Doc] =
-    chunks.foldRight(Chunk.empty[Doc])(chunked((x, y) => x.withLine(Doc.empty).withLine(y)))
+    chunks.foldRight(Chunk.empty[Doc])(chunked((x, y) => x.withLine(Doc.Empty).withLine(y)))
 
   def extract[A : Monoid](chunk: Chunk[A]): A =
     chunk.run.orZero

--- a/src/main/scala/net/bmjames/opts/helpdoc/ParserHelp.scala
+++ b/src/main/scala/net/bmjames/opts/helpdoc/ParserHelp.scala
@@ -39,6 +39,6 @@ object ParserHelp {
     extract(vsepChunks(List(help.error, help.header, help.usage, help.body, help.footer)))
 
   /** Convert a help text to a String */
-  def renderHelp(cols: Int, help: ParserHelp): String = Doc.prettyRender(cols, helpText(help))
+  def renderHelp(cols: Int, help: ParserHelp): String = helpText(help).pretty(cols)
 
 }

--- a/src/main/scala/net/bmjames/opts/types/Doc.scala
+++ b/src/main/scala/net/bmjames/opts/types/Doc.scala
@@ -62,12 +62,12 @@ object Doc {
     (p: Position, dq: Dq) =>
       done(
         (r: Remaining) =>
-          dq.dequeueOption match {
-            case Some(((s, grp), tail)) =>
+          dq.headOption match {
+            case Some((s, grp)) =>
               if (p > s + r) {
                 suspend(
                   for {
-                    cont2 <- prune(cont1)(p, tail)
+                    cont2 <- prune(cont1)(p, dq.tail)
                     out <- grp(false)(cont2)
                     layout <- out(r)
                   } yield layout)

--- a/src/test/scala/net/bmjames/opts/test/DocSpec.scala
+++ b/src/test/scala/net/bmjames/opts/test/DocSpec.scala
@@ -7,19 +7,13 @@ import Arbitrary._, Gen._
 
 object DocSpec extends Properties("Doc") {
   val stringDocGen = arbitrary[String].map(Doc.string(_))
-  val lineOrEmptyDocGen = Gen.oneOf(Doc.line, Doc.empty)
+  val lineOrEmptyDocGen = Gen.oneOf(Doc.line, Doc.Empty)
   val appendDocGen = Gen.listOfN(10, Gen.frequency((3, stringDocGen), (1, lineOrEmptyDocGen))).map{
     _.reduce(Doc.append(_,_))
   }
   implicit val arbDoc = Arbitrary(appendDocGen)
   def equalDocs(w: Int, d1: Doc, d2: Doc): Boolean =
     Doc.prettyRender(w, d1) == Doc.prettyRender(w, d2)
-
-  property("flatten has longer first line") = forAll(posNum[Int], arbitrary[Doc]) { (w, doc) =>
-    val docResult = Doc.prettyRender(w, doc)
-    val flatResult = Doc.prettyRender(w, Doc.flatten(doc))
-    docResult.takeWhile(_ != '\n').length <= flatResult.takeWhile(_ != '\n').length
-  }
 
   property("text append is same as concat of strings") = forAll(posNum[Int], arbitrary[String], arbitrary[String]){ (w, s1, s2) =>
    equalDocs(w, Doc.string(s1 ++ s2), Doc.append(Doc.string(s1), Doc.string(s2)))


### PR DESCRIPTION
A port of https://www.cs.kent.ac.uk/pubs/2009/2847/content.pdf section 3.3 to scala using trampolining to make it the most hideous thing to read (oh, and to make it work in Scala).

It fixes #15, which I have locally, but I wasn't sure if we should check it into the tests? I'd be happy to add scalatest or specs and add the large parser to ensure it doesn't take longer than a certain amount of time to execute.

I'll be taking this idea and expanding it out for a pretty printing library, if I do I'll contribute back changes or link to the lib directly if that makes sense.